### PR TITLE
Setting target to node-webkit

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,5 +42,6 @@ module.exports = {
   plugins: [
     new CommonsChunkPlugin({ name: 'angular2', filename: 'angular2.js', minChunks: Infinity }),
     new CommonsChunkPlugin({ name: 'common',   filename: 'common.js' })
-  ]
+  ],
+  target:'node-webkit'
 };


### PR DESCRIPTION
I've added the `target:'node-webkit'` option to webpack to allow importing electron modules like fs, otherwise they would work when called from JS but not from TypeScript (don't know why...).

Example:
`import fs = require('fs');`

BTW: I don't know why this doesn't work when the target is set to 'atom'...
